### PR TITLE
Add binary file format

### DIFF
--- a/src/AnimationClip.cpp
+++ b/src/AnimationClip.cpp
@@ -5,11 +5,11 @@ namespace fbxconv {
 		animations.push_back(animation);
 	}
 
-	G3djAnimation* AnimationClip::getAnimation(unsigned int index){
+	G3djAnimation* AnimationClip::getAnimation(unsigned int index) const {
 		return animations[index];
 	}
 
-	unsigned int AnimationClip::getAnimationCount(){
+	unsigned int AnimationClip::getAnimationCount() const {
 		return animations.size();
 	}
 
@@ -18,9 +18,7 @@ namespace fbxconv {
 		strcpy(this->clipId, clipId);
 	}
 
-	char* AnimationClip::getClipId(){
+	char* AnimationClip::getClipId() const {
 		return clipId;
 	}
-
-
 };

--- a/src/AnimationClip.h
+++ b/src/AnimationClip.h
@@ -10,10 +10,10 @@ namespace fbxconv {
 		void setClipId(const char* clipId);
 
 		void addAnimation(G3djAnimation* animation);
-		G3djAnimation* getAnimation(unsigned int index);
+		G3djAnimation* getAnimation(unsigned int index) const;
 
-		unsigned int getAnimationCount();
-		char* getClipId();
+		unsigned int getAnimationCount() const;
+		char* getClipId() const;
 	private:
 		std::vector<G3djAnimation*> animations;
 		char* clipId;

--- a/src/G3dbWriter.cpp
+++ b/src/G3dbWriter.cpp
@@ -1,0 +1,341 @@
+#include "G3dbWriter.h"
+
+const int one = 1;
+#define is_bigendian() ( (*(char*)&one) == 0 )
+
+namespace fbxconv {
+	bool G3dbWriter::exportG3db(G3djFile &g3dj, const char *fileName) {
+		file = fopen(fileName, "wb");
+		if (!file) {
+			printf("Could not open %s for write mode", fileName);
+			return false;
+		}
+		bool result = true;
+		try {
+			writeTag();
+			writeVersion();
+			writeNull(32-8);
+			const unsigned int nm = g3dj.getMeshCount();
+			for (unsigned int i = 0; i < nm; i++)
+				writeMesh(*g3dj.getMesh(i));
+			const unsigned int nt = g3dj.getMaterialCount();
+			for (unsigned int i = 0; i < nt; i++)
+				writeMaterial(*g3dj.getMaterial(i));
+			const unsigned int nn = g3dj.getNodeCount();
+			for (unsigned int i = 0; i < nn; i++)
+				writeNode(*g3dj.getNode(i));
+			const unsigned int an = g3dj.getAnimationClipCount();
+			for (unsigned int i = 0; i < an; i++)
+				writeAnimationClip(*g3dj.getAnimationClip(i));
+		}
+		catch(const char *err) {
+			printf("%s\n", err);
+			result = false;
+		}
+		fclose(file);
+		return result;
+	}
+
+	void G3dbWriter::writeTag() {
+		fputs(G3DB_TAG, file);
+	}
+
+	void G3dbWriter::writeVersion() {
+		writeShort(versionHi);
+		writeShort(versionLo);
+	}
+
+	void G3dbWriter::writeNull(const int &size) {
+		for (int i = 0; i < size; i++)
+			writeByte(0);
+	}
+
+	void G3dbWriter::writeMesh(const Mesh &mesh) {
+		unsigned char vtag = G3DB_TAG_VERTICES;
+
+		long *meshBlock = beginBlock(G3DB_TAG_MESH, LARGE_MAX);
+
+		writeString(G3DB_TAG_ID, mesh.getId().c_str());
+
+		unsigned int n = mesh.getVertexElementCount();
+		writeTag(G3DB_TAG_ATTRIBUTES, n);
+		for (unsigned int i = 0; i < n; i++)
+			writeByte(mesh.getVertexElement(i).usage);
+
+		long *verticesBlock = beginBlock(G3DB_TAG_VERTICES, LARGE_MAX);
+		n = mesh.getVertexCount();
+		for (unsigned int i = 0; i < n; i++) {
+			const Vertex vertex = mesh.getVertex(i);
+			writeVector(vertex.position);
+			if (vertex.hasNormal)
+				writeVector(vertex.normal);
+			if (vertex.hasTangent)
+				writeVector(vertex.tangent);
+			if (vertex.hasBinormal)
+				writeVector(vertex.binormal);
+			for (unsigned int i = 0; i < MAX_UV_SETS; i++)
+				if (vertex.hasTexCoord[i])
+					writeVector(vertex.texCoord[i]);
+			if (vertex.hasDiffuse) {
+				writeFloat(vertex.diffuse.x);
+				writeFloat(vertex.diffuse.y);
+				writeFloat(vertex.diffuse.z);
+			}
+			if (vertex.hasWeights) {
+				writeVector(vertex.blendWeights);
+				writeVector(vertex.blendIndices);
+			}
+		}
+		endBlock(verticesBlock);
+
+		n = mesh.parts.size();
+		for (unsigned int i = 0; i < n; i++) {
+			long *partBlock = beginBlock(G3DB_TAG_MESHPART, LARGE_MAX);
+			writeString(G3DB_TAG_ID, mesh.parts[i]->getId().c_str());
+			writeTag(G3DB_TAG_TYPE, 1);
+			writeByte((unsigned char)mesh.parts[i]->_primitiveType);
+			short c = mesh.parts[i]->getIndicesCount();
+			writeTag((char)G3DB_TAG_INDICES, c*2);
+			for (short j = 0; j < c; j++)
+				writeShort(mesh.parts[i]->getIndex(j));
+			endBlock(partBlock);
+		}
+
+		endBlock(meshBlock);
+	}
+
+	void G3dbWriter::writeMaterial(G3djMaterial &material) {
+		long *materialBlock = beginBlock(G3DB_TAG_MATERIAL, MEDIUM_MAX);
+		writeString(G3DB_TAG_ID, material.getId().c_str());
+		writeByte(G3DB_TAG_TYPE, material.getMaterialType());
+		writeVector(G3DB_TAG_DIFFUSE, material.getDiffuse());
+		writeVector(G3DB_TAG_AMBIENT, material.getAmbient());
+		writeVector(G3DB_TAG_EMMISIVE, material.getEmissive());
+		writeFloat(G3DB_TAG_OPACITY, material.getOpacity());
+		if(material.getMaterialType() == PHONG){
+			writeVector(G3DB_TAG_SPECULAR, material.getSpecular());
+			writeFloat(G3DB_TAG_SHININESS, material.getShininess());
+		}
+		unsigned int n = material.getTextureCount();
+		for (unsigned int i = 0; i < n; i++) {
+			Texture *texture = material.getTexture(i);
+			long *textureBlock = beginBlock(G3DB_TAG_TEXTURE, MEDIUM_MAX);
+			writeString(G3DB_TAG_ID, texture->getId());
+			writeString(G3DB_TAG_FILENAME, texture->getRelativePath());
+			writeByte(G3DB_TAG_TYPE, texture->textureUse);
+			writeVector(G3DB_TAG_TRANSLATE, texture->uvTranslation);
+			writeVector(G3DB_TAG_SCALE, texture->uvScale);
+			endBlock(textureBlock);
+		}
+		endBlock(materialBlock);
+	}
+
+	void G3dbWriter::writeNode(const G3djNode &node) {
+		long *nodeBlock = beginBlock(G3DB_TAG_NODE, LARGE_MAX);
+		writeString(G3DB_TAG_ID, node.getId().c_str());
+		writeByte(G3DB_TAG_BONE, node.isJoint() ? 1 : 0);
+		writeVector(G3DB_TAG_TRANSLATE, node.getTranslation());
+		writeQuaternion(G3DB_TAG_ROTATE, node.getRotation());
+		writeVector(G3DB_TAG_SCALE, node.getScale());
+		if (node.getModel() != NULL) {
+			gameplay::Mesh *mesh = node.getModel()->getMesh();
+			writeString(G3DB_TAG_MESH, mesh->getId().c_str());
+			const unsigned int n = mesh->parts.size();
+			for (unsigned int i = 0; i < n; i++) {
+				long *partMaterialBlock = beginBlock(G3DB_TAG_PARTMATERIAL, SMALL_MAX);
+				writeString(G3DB_TAG_MESHPART, mesh->parts[i]->getId().c_str());
+				writeString(G3DB_TAG_MATERIAL, ((G3djMeshPart*)(mesh->parts[i]))->getMaterialId());
+				endBlock(partMaterialBlock);
+			}
+		}
+		if (node.hasChildren()) {
+			for (G3djNode* cnode = dynamic_cast<G3djNode*>(node.getFirstChild()); cnode != NULL; cnode = dynamic_cast<G3djNode*>(cnode->getNextSibling())) {
+				writeNode(*cnode);
+			}
+		}
+		endBlock(nodeBlock);
+	}
+
+	void G3dbWriter::writeAnimationClip(const AnimationClip &clip) {
+		long *clipBlock = beginBlock(G3DB_TAG_ANIMATIONCLIP, LARGE_MAX);
+		writeString(G3DB_TAG_ID, clip.getClipId());
+		const unsigned int n = clip.getAnimationCount();
+		for (unsigned int i = 0; i < n; i++) {
+			G3djAnimation *animation = clip.getAnimation(i);
+			long *boneBlock = beginBlock(G3DB_TAG_BONE, LARGE_MAX);
+			writeString(G3DB_TAG_ID, animation->getBoneId());
+			const unsigned int kn = animation->getKeyframeCount();
+			for (unsigned int j = 0; j < kn; j++) {
+				Keyframe *keyframe = animation->getKeyframe(j);
+				long *keyframeBlock = beginBlock(G3DB_TAG_KEYFRAME, SMALL_MAX);
+				writeFloat(G3DB_TAG_TIME, keyframe->keytime);
+				writeVector(G3DB_TAG_TRANSLATE, keyframe->translation);
+				writeQuaternion(G3DB_TAG_ROTATE, keyframe->rotation);
+				writeVector(G3DB_TAG_SCALE, keyframe->scale);
+				endBlock(keyframeBlock);
+			}
+			endBlock(boneBlock);
+		}
+		endBlock(clipBlock);
+	}
+
+	void G3dbWriter::writeFloat(const float &value) {
+		if (!is_bigendian()) {
+			swapper.f = value;
+			swapper.swap4();
+			fwrite((void*)&(swapper.f), 4, 1, file);
+		} else
+			fwrite((void*)&value, 4, 1, file);
+	}
+
+	void G3dbWriter::writeInt(const int &value) {
+		if (!is_bigendian()) {
+			swapper.i = value;
+			swapper.swap4();
+			fwrite((void*)&(swapper.i), 4, 1, file);
+		} else
+			fwrite((void*)&value, 4, 1, file);
+	}
+
+	void G3dbWriter::writeLong(const long &value) {
+		if (!is_bigendian()) {
+			swapper.l = value;
+			swapper.swap8();
+			fwrite((void*)&(swapper.l), 8, 1, file);
+		} else
+			fwrite((void*)&value, 8, 1, file);
+	}
+
+	void G3dbWriter::writeShort(const short &value) {
+		if (!is_bigendian()) {
+			swapper.s = value;
+			swapper.swap2();
+			fwrite((void*)&(swapper.s), 2, 1, file);
+		} else
+			fwrite((void*)&value, 2, 1, file);
+	}
+
+	void G3dbWriter::writeByte(const unsigned char &value) {
+		fwrite((void*)&value, 1, 1, file);
+	}
+
+	void G3dbWriter::writeString(const char *value) {
+		fputs(value, file);
+	}
+
+	void G3dbWriter::writeVector(const gameplay::Vector2 &value) {
+		writeFloat(value.x);
+		writeFloat(value.y);
+	}
+
+	void G3dbWriter::writeVector(const gameplay::Vector3 &value) {
+		writeFloat(value.x);
+		writeFloat(value.y);
+		writeFloat(value.z);
+	}
+
+	void G3dbWriter::writeVector(const gameplay::Vector4 &value) {
+		writeFloat(value.x);
+		writeFloat(value.y);
+		writeFloat(value.z);
+		writeFloat(value.w);
+	}
+
+	void G3dbWriter::writeQuaternion(const gameplay::Quaternion &value) {
+		writeFloat(value.x);
+		writeFloat(value.y);
+		writeFloat(value.z);
+		writeFloat(value.w);
+	}
+
+	int G3dbWriter::writeSize(const unsigned char &tag, const long &size) {
+		if ((tag & XLARGE) == SMALL) {
+			writeByte((unsigned char)size);
+			return 1;
+		} else if ((tag & XLARGE) == MEDIUM) {
+			writeShort((short)size);
+			return 2;
+		} else if ((tag & XLARGE) == LARGE) {
+			writeInt(size);
+			return 4;
+		} else {
+			writeLong(size);
+			return 8;
+		}
+	}
+
+	int G3dbWriter::writeTag(unsigned char tag, const long &size) {
+		if (size <= SMALL_MAX)
+			tag |= SMALL;
+		else if (size <= MEDIUM_MAX)
+			tag |= MEDIUM;
+		else if (size <= LARGE_MAX)
+			tag |= LARGE;
+		else
+			tag |= XLARGE;
+		writeByte(tag);
+		return 1 + writeSize(tag, size);
+	}
+
+	void G3dbWriter::writeString(const unsigned char &tag, const char *value) {
+		writeTag(tag, strlen(value));
+		writeString(value);
+	}
+
+	void G3dbWriter::writeVector(const unsigned char &tag, const gameplay::Vector2 &value) {
+		writeTag(tag, 2*4);
+		writeVector(value);
+	}
+
+	void G3dbWriter::writeVector(const unsigned char &tag, const gameplay::Vector3 &value) {
+		writeTag(tag, 3*4);
+		writeVector(value);
+	}
+
+	void G3dbWriter::writeQuaternion(const unsigned char &tag, const gameplay::Quaternion &value) {
+		writeTag(tag, 4*4);
+		writeQuaternion(value);
+	}
+
+	void G3dbWriter::writeFloat(const unsigned char &tag, const float &value) {
+		writeTag(tag, 4);
+		writeFloat(value);
+	}
+
+	void G3dbWriter::writeByte(const unsigned char &tag, const unsigned char &value) {
+		writeTag(tag, 1);
+		writeByte(value);
+	}
+
+	long *G3dbWriter::beginBlock(const unsigned char &tag, const long &maxSize) {
+		long *block = new long[2];
+		block[0] = writeTag(tag, maxSize) - 1;
+		block[1] = ftell(file);
+		return block;
+	}
+
+	void G3dbWriter::endBlock(const long *block) {
+		long pos = ftell(file);
+		long size = pos - block[1];
+		fseek(file, block[1] - block[0], SEEK_SET);
+		if (block[0] == 1) {
+			if (size > SMALL_MAX)
+				throw "Data overflow detected";
+			writeByte((unsigned char)size);
+		} else if (block[0] == 2) {
+			if (size > MEDIUM_MAX)
+				throw "Data overflow detected";
+			writeShort((short)size);
+		} else if (block[0] == 4) {
+			if (size > LARGE_MAX)
+				throw "Data overflow detected";
+			writeInt(size);
+		} else {
+			if (size > XLARGE_MAX)
+				throw "Data overflow detected";
+			writeLong(size);
+		}
+		fseek(file, pos, SEEK_SET);
+		delete[] block;
+	}
+}

--- a/src/G3dbWriter.h
+++ b/src/G3dbWriter.h
@@ -1,0 +1,127 @@
+/**
+ * File specification:
+ *  0.. 3 Identifyer (must be "G3DB")
+ *  4.. 5 File version high part
+ *  6.. 7 File version low part
+ *  8..31 Reserved, must be 0
+ * 32..EOF Data blocks, where each block is defined as:
+ * 1 byte: SSTTTTTT: 
+ * - SS: the size of the next value (00 = 1 byte, 01 = 2 bytes, 10 = 4 bytes, 11 = 8 bytes)
+ * - TTTTTT: the block type
+ * SS bytes: the size of the (rest of the) block in bytes
+ */
+#ifndef G3DBWRITER_H
+#define G3DBWRITER_H
+
+#include <stdio.h>
+#include "G3djFile.h"
+#include "G3djMeshPart.h"
+
+#define G3DB_TAG			"G3DB"
+#define G3DB_VERSION_HI		0
+#define G3DB_VERSION_LO		1
+
+#define SMALL	0x00
+#define MEDIUM	0x40
+#define LARGE	0x80
+#define XLARGE	0xC0
+
+#define SMALL_MAX	(((unsigned long)1 << 8) - 1)
+#define MEDIUM_MAX	(((unsigned long)1 << 15) - 1)
+#define LARGE_MAX	(((unsigned long)1 << 31) - 1)
+#define XLARGE_MAX	(((unsigned long long)1 << 63) - 1)
+
+#define G3DB_TAG_MESH			0x01
+#define G3DB_TAG_ID				0x02
+#define G3DB_TAG_ATTRIBUTES		0x03
+#define G3DB_TAG_VERTICES		0x04
+#define G3DB_TAG_MESHPART		0x05
+#define G3DB_TAG_TYPE			0x06
+#define G3DB_TAG_INDICES		0x07
+#define G3DB_TAG_MATERIAL		0x08
+#define G3DB_TAG_DIFFUSE		0x09
+#define G3DB_TAG_AMBIENT		0x0A
+#define G3DB_TAG_EMMISIVE		0x0B
+#define G3DB_TAG_OPACITY		0x0C
+#define G3DB_TAG_SPECULAR		0x0D
+#define G3DB_TAG_SHININESS		0x0E
+#define G3DB_TAG_NODE			0x0F
+#define G3DB_TAG_TRANSLATE		0x10
+#define G3DB_TAG_ROTATE			0x11
+#define G3DB_TAG_SCALE			0x12
+#define G3DB_TAG_PARTMATERIAL	0x13
+#define G3DB_TAG_TEXTURE		0x14
+#define G3DB_TAG_FILENAME		0x15
+#define G3DB_TAG_ANIMATIONCLIP	0x16
+#define G3DB_TAG_BONE			0x17
+#define G3DB_TAG_KEYFRAME		0x18
+#define G3DB_TAG_TIME			0x19
+
+#define SWAP(X,Y,T) {T=X; X=Y; Y=T;}
+
+namespace fbxconv {
+	typedef union {
+		short s;
+		float f;
+		int i;
+		long l;
+		char data[8];
+		void swap2() {
+			char tmp;
+			SWAP(data[0], data[1], tmp);
+		}
+		void swap4() {
+			char tmp;
+			SWAP(data[0], data[3], tmp);
+			SWAP(data[1], data[2], tmp);
+		}
+		void swap8() {
+			char tmp;
+			SWAP(data[0], data[7], tmp);
+			SWAP(data[1], data[6], tmp);
+			SWAP(data[2], data[5], tmp);
+			SWAP(data[3], data[4], tmp);
+		}
+	} EndianSwapper;
+
+	class G3dbWriter {
+	public:
+		static const short versionHi = G3DB_VERSION_HI;
+		static const short versionLo = G3DB_VERSION_LO;
+	private:
+		FILE * file;
+		EndianSwapper swapper;
+
+		void writeTag();
+		void writeVersion();
+		void writeNull(const int &size);
+		void writeMesh(const Mesh &mesh);
+		void writeMaterial(G3djMaterial &material);
+		void writeNode(const G3djNode &node);
+		void writeAnimationClip(const AnimationClip &clip);
+		void writeFloat(const float &value);
+		void writeLong(const long &value);
+		void writeInt(const int &value);
+		void writeShort(const short &value);
+		void writeByte(const unsigned char &value);
+		void writeString(const char *value);
+		void writeVector(const gameplay::Vector2 &value);
+		void writeVector(const gameplay::Vector3 &value);
+		void writeVector(const gameplay::Vector4 &value);
+		void writeQuaternion(const gameplay::Quaternion &value);
+		int writeSize(const unsigned char &tag, const long &size);
+		int writeTag(unsigned char tag, const long &size);
+		void writeString(const unsigned char &tag, const char *value);
+		void writeVector(const unsigned char &tag, const gameplay::Vector2 &value);
+		void writeVector(const unsigned char &tag, const gameplay::Vector3 &value);
+		void writeQuaternion(const unsigned char &tag, const gameplay::Quaternion &value);
+		void writeFloat(const unsigned char &tag, const float &value);
+		void writeByte(const unsigned char &tag, const unsigned char &value);
+		long *beginBlock(const unsigned char &tag, const long &maxSize);
+		void endBlock(const long *block);
+	public:
+		bool exportG3db(G3djFile &g3dj, const char *fileName);
+	};
+}
+
+#endif // G3DBWRITER_H

--- a/src/G3djFile.cpp
+++ b/src/G3djFile.cpp
@@ -103,19 +103,19 @@ namespace fbxconv {
 		return animationClips[clipIndex];
 	}
 
-	unsigned int G3djFile::getNodeCount(){
+	unsigned int G3djFile::getNodeCount() const {
 		return nodes.size();
 	}
 
-	unsigned int G3djFile::getMeshCount(){
+	unsigned int G3djFile::getMeshCount() const {
 		return meshes.size();
 	}
 
-	unsigned int G3djFile::getMaterialCount(){
+	unsigned int G3djFile::getMaterialCount() const {
 		return materials.size();
 	}
 
-	unsigned int G3djFile::getAnimationClipCount(){
+	unsigned int G3djFile::getAnimationClipCount() const {
 		return animationClips.size();
 	}
 };

--- a/src/G3djFile.h
+++ b/src/G3djFile.h
@@ -35,10 +35,10 @@ namespace fbxconv {
 
 		AnimationClip* getAnimationClip(unsigned int clipIndex);
 
-		unsigned int getMeshCount();
-		unsigned int getNodeCount();
-		unsigned int getMaterialCount();
-		unsigned int getAnimationClipCount();
+		unsigned int getMeshCount() const;
+		unsigned int getNodeCount() const;
+		unsigned int getMaterialCount() const;
+		unsigned int getAnimationClipCount() const;
 	private:
 		Scene* scene;
 

--- a/src/G3djMaterial.cpp
+++ b/src/G3djMaterial.cpp
@@ -10,11 +10,11 @@ namespace fbxconv {
 	
 	}
 
-	unsigned int G3djMaterial::getMaterialType(){
+	unsigned int G3djMaterial::getMaterialType() const {
 		return materialType;
 	}
 
-	std::string G3djMaterial::getId(){
+	std::string G3djMaterial::getId() const {
 		return id;
 	}
 
@@ -22,7 +22,7 @@ namespace fbxconv {
 		diffuse.set(r, g, b);
 	}
 
-	Vector3 G3djMaterial::getDiffuse(){
+	Vector3 G3djMaterial::getDiffuse() const {
 		return diffuse;
 	}
 
@@ -30,7 +30,7 @@ namespace fbxconv {
 		ambient.set(r, g, b);
 	}
 
-	Vector3 G3djMaterial::getAmbient(){
+	Vector3 G3djMaterial::getAmbient() const {
 		return ambient;
 	}
 
@@ -38,7 +38,7 @@ namespace fbxconv {
 		emissive.set(r, g, b);
 	}
 
-	Vector3 G3djMaterial::getEmissive(){
+	Vector3 G3djMaterial::getEmissive() const {
 		return emissive;
 	}
 
@@ -46,7 +46,7 @@ namespace fbxconv {
 		specular.set(r, g, b);
 	}
 
-	Vector3 G3djMaterial::getSpecular(){
+	Vector3 G3djMaterial::getSpecular() const {
 		return specular;
 	}
 
@@ -54,7 +54,7 @@ namespace fbxconv {
 		opacity = a;
 	}
 
-	float G3djMaterial::getOpacity(){
+	float G3djMaterial::getOpacity() const {
 		return opacity;
 	}
 
@@ -62,7 +62,7 @@ namespace fbxconv {
 		this->shininess = shininess;
 	}
 
-	float G3djMaterial::getShininess(){
+	float G3djMaterial::getShininess() const {
 		return shininess;
 	}
 
@@ -70,11 +70,11 @@ namespace fbxconv {
 		textures[texture->getId()] = texture;
 	}
 
-	unsigned int G3djMaterial::getTextureCount(){
+	unsigned int G3djMaterial::getTextureCount() const {
 		return textures.size();
 	}
 
-	Texture* G3djMaterial::getTexture(const char* id){
+	Texture* G3djMaterial::getTexture(const char* id) {
 		std::map<std::string, Texture*>::iterator it = textures.find(id);
 		if (it != textures.end())
 		{
@@ -83,7 +83,7 @@ namespace fbxconv {
 		return NULL;
 	}
 
-	Texture* G3djMaterial::getTexture(unsigned int index){
+	Texture* G3djMaterial::getTexture(unsigned int index) {
 		// Ugh, this seems ugly. But without having a second flat list I don't see a better way right now.
 		if(index >= textures.size())
 			return NULL;

--- a/src/G3djMaterial.h
+++ b/src/G3djMaterial.h
@@ -21,9 +21,9 @@ namespace fbxconv {
 		G3djMaterial(const char* pId, unsigned int pMaterialType);
 		~G3djMaterial();
 
-		std::string getId();
+		std::string getId() const;
 
-		unsigned int getMaterialType();
+		unsigned int getMaterialType() const;
 
 		void setDiffuse(float r, float g, float b);
 		void setAmbient(float r, float g, float b);
@@ -32,19 +32,19 @@ namespace fbxconv {
 		void setOpacity(float a);
 		void setShininess(float shininess);
 
-		Vector3 getDiffuse();
-		Vector3 getAmbient();
-		Vector3 getEmissive();
-		Vector3 getSpecular();
-		float getOpacity();
-		float getShininess();
+		Vector3 getDiffuse() const;
+		Vector3 getAmbient() const;
+		Vector3 getEmissive() const;
+		Vector3 getSpecular() const;
+		float getOpacity() const;
+		float getShininess() const;
 
 		void addTexture(Texture *texture);
 
 		Texture* getTexture(const char* id);
 		Texture* getTexture(unsigned int index);
 
-		unsigned int getTextureCount();
+		unsigned int getTextureCount() const;
 
 	private:
 		std::string id;

--- a/src/G3djNode.cpp
+++ b/src/G3djNode.cpp
@@ -13,15 +13,15 @@ namespace fbxconv {
 		scale.set(x, y, z);
 	}
 
-	Vector3 G3djNode::getTranslation(){
+	Vector3 G3djNode::getTranslation() const {
 		return translation;
 	}
 
-	Quaternion G3djNode::getRotation(){
+	Quaternion G3djNode::getRotation() const {
 		return rotation;
 	}
 
-	Vector3 G3djNode::getScale(){
+	Vector3 G3djNode::getScale() const {
 		return scale;
 	}
 }

--- a/src/G3djNode.h
+++ b/src/G3djNode.h
@@ -14,9 +14,9 @@ namespace fbxconv {
 		void setRotation(float x, float y, float z, float w);
 		void setScale(float x, float y, float z);
 
-		Vector3 getTranslation();
-		Quaternion getRotation();
-		Vector3 getScale();
+		Vector3 getTranslation() const;
+		Quaternion getRotation() const;
+		Vector3 getScale() const;
 
 	private:
 		Vector3 translation;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,47 +1,202 @@
 #include "FbxConverter.h"
 #include "G3djWriter.h"
+#include "G3dbWriter.h"
 #include <string>
+
+// #define COMMAND_INPUT_TYPE
 
 using namespace fbxconv;
 using namespace gameplay;
 
+static const int AUTO=0x00;
+static const int FBX=0x10;
+static const int G3DB=0x20;
+static const int G3DJ=0x21;
+
+typedef struct {
+	std::string error;
+	std::string inFile;
+	int inType;
+	std::string outFile;
+	int outType;
+	bool flipV;
+} FbxConvCommand;
+
+void printHelp() {
+	printf("Usage: fbx-conv.exe [options] <input> [<output>]\n");
+	printf("\n");
+	printf("Options:\n");
+#ifdef COMMAND_INPUT_TYPE
+	printf("-in <type>:\tSet the type of the input file to <type>\n");
+#endif
+	printf("-out <type>:\tSet the type of the output file to <type>\n");
+	printf("-flipV:\t\tFlip the V texture coordinates.\n");
+	printf("\n");
+	printf("<input>:\tThe filename of the file to convert.\n");
+	printf("<output>:\tThe filename of the converted file.\n");
+	printf("\n");
+	printf("<type>:\t\tG3DJ (json) or G3DB (binary).\n");
+}
+
+inline int parseType(const char* arg) {
+	if (stricmp(arg, "fbx")==0)
+		return FBX;
+	else if (stricmp(arg, "g3db")==0)
+		return G3DB;
+	else if (stricmp(arg, "g3dj")==0)
+		return G3DJ;
+	return -1;
+}
+
+inline int guessType(const std::string &fn, int def) {
+	int o = fn.find_last_of('.');
+	if (o == std::string::npos)
+		return def;
+	std::string ext = fn.substr(++o, fn.length() - o);
+	int r = parseType(ext.c_str());
+	return r < 0 ? def : r;
+}
+
+inline void setExtension(std::string &fn, const std::string &ext) {
+	int o = fn.find_last_of('.');
+	if (o == std::string::npos)
+		fn += "." + ext;
+	else
+		fn = fn.substr(0, ++o) + ext;
+}
+
+inline void setExtension(std::string &fn, int type) {
+	switch(type) {
+	case FBX: setExtension(fn, "fbx"); break;
+	case G3DB: setExtension(fn, "g3db"); break;
+	case G3DJ: setExtension(fn, "g3dj"); break;
+	}
+}
+
+FbxConvCommand parseCommand(int argc, const char** argv) {
+	FbxConvCommand result;
+	result.inType = AUTO;
+	result.outType = AUTO;
+	result.flipV = false;
+	for (int i = 1; i < argc; i++) {
+		if (argv[i][0] == '-' && i < argc - 1 && strlen(argv[i]) > 1) {
+			if (argv[i][1] == 'o') {
+				result.outType = parseType(argv[++i]);
+				if (result.outType < 0) {
+					result.error = "Unknown output type: ";
+					result.error += argv[i];
+					return result;
+				}
+			}
+#ifdef COMMAND_INPUT_TYPE
+			else if (argv[i][1] == 'i') {
+				result.inType = parseType(argv[++i]);
+				if (result.inType < 0) {
+					result.error = "Unknown input type: ";
+					result.error += argv[i];
+					return result;
+				}
+			}
+#endif
+			else if (argv[i][1] == 'f')
+				result.flipV = true;
+		}
+		else if (result.inFile.length() < 1)
+			result.inFile = argv[i];
+		else if (result.outFile.length() < 1)
+			result.outFile = argv[i];
+		else {
+			result.error = "Unknown commandline option: ";
+			result.error += argv[i];
+			return result;
+		}
+	}
+	if (result.inFile.length() < 1) {
+		result.error = "No input file specified.";
+		return result;
+	}
+	if (result.inType == AUTO)
+#ifdef COMMAND_INPUT_TYPE
+		result.inType = guessType(result.inFile, FBX);
+#else
+		result.inType = FBX;
+#endif
+	if (result.inType != FBX) {
+		result.error = "Unsupported input type, only FBX is supported";
+		return result;
+	}
+	if (result.outType == AUTO)
+		result.outType = guessType(result.outFile, G3DJ);
+	if (result.outType != G3DJ && result.outType != G3DB) {
+		result.error = "Unsupported output type, only G3DJ or G3DB is supported";
+		return result;
+	}
+	if (result.outFile.empty()) {
+		result.outFile = result.inFile;
+		setExtension(result.outFile, result.outType);
+	}
+	return result;
+}
+
+void flipV(G3djFile *file) {
+	unsigned int size = file->getMeshCount();
+	int *cnt = new int[8];
+	memset(cnt, 0, 8*4);
+	for (unsigned int i = 0; i < size; i++) {
+		Mesh *mesh = file->getMesh(i);
+		unsigned int n = mesh->getVertexCount();
+		for (unsigned int j = 0; j < n; j++) {
+			Vertex *vertex = &(mesh->vertices.at(j));
+			if (vertex->hasTexCoord[0])
+				vertex->texCoord[0].y = 1.0f - vertex->texCoord[0].y;
+			if (vertex->hasTexCoord[1])
+				vertex->texCoord[1].y = 1.0f - vertex->texCoord[1].y;
+			if (vertex->hasTexCoord[2])
+				vertex->texCoord[2].y = 1.0f - vertex->texCoord[2].y;
+			if (vertex->hasTexCoord[3])
+				vertex->texCoord[3].y = 1.0f - vertex->texCoord[3].y;
+			if (vertex->hasTexCoord[4])
+				vertex->texCoord[4].y = 1.0f - vertex->texCoord[4].y;
+			if (vertex->hasTexCoord[5])
+				vertex->texCoord[5].y = 1.0f - vertex->texCoord[5].y;
+			if (vertex->hasTexCoord[6])
+				vertex->texCoord[6].y = 1.0f - vertex->texCoord[6].y;
+			if (vertex->hasTexCoord[7])
+				vertex->texCoord[7].y = 1.0f - vertex->texCoord[7].y;
+		}
+	}
+}
+
 int main(int argc, const char** argv) {
-	if (argc == 1)
+	FbxConvCommand command = parseCommand(argc, argv);
+	if (command.error.length() > 0)
 	{
-		printf("Missing: file to convert\n");
+		printf("ERROR: %s\n\n", command.error.c_str());
+		printHelp();
 		return 1;
 	}
-	std::string file = argv[1];
 
 	FbxConverterConfig config = FbxConverterConfig();
 	config.flipV = false;
 
 	FbxConverter converter(config);
-	G3djFile *g3djFile = converter.load(file.c_str());
+	G3djFile *g3djFile = converter.load(command.inFile.c_str());
 
-	printf("Exporting to json.\n");
-	G3djWriter *writer = new G3djWriter();
-
-	// either use the second parameter as output filename, or if there is no
-	// second parameter, then use the file/path of the input file with a new
-	// "g3dj" extension
-	std::string outputFile;
-	if (argc == 3)
-		outputFile = argv[2];
-	else
-	{
-		size_t extensionStartPos = file.find_last_of('.');
-		outputFile = file;
-		if (extensionStartPos != std::string::npos)
-		{
-			outputFile.erase(extensionStartPos, std::string::npos);
-			outputFile.append(".g3dj");
-		}
-		else
-			outputFile.append(".g3dj");
+	if (command.flipV) {
+		printf("Flipping V\n");
+		flipV(g3djFile);
 	}
-	
-	writer->exportG3dj(g3djFile, outputFile.c_str());
+
+	if (command.outType == G3DJ) {
+		printf("Exporting to json.\n");
+		G3djWriter writer;
+		writer.exportG3dj(g3djFile, command.outFile.c_str());
+	} else {
+		printf("Exporting to binary.\n");
+		G3dbWriter writer;
+		if (!writer.exportG3db(*g3djFile, command.outFile.c_str()))
+			printf("Error while exporting to binary\n");
+	}
 
 	printf("Done.\n");
 


### PR DESCRIPTION
Add a simple, but flexible binary file format. Also add some command line options to specify the format and the ability to flipV (maya uses y-up for uv).

The file format consist of a header and a bunch of data blocks:

The header is always 32 bytes of which the first 4 bytes contain the file tag "G3DB" and the second 4 bytes the file version. The rest of the header (24 bytes) is reserved for future usage and set to 0.

A data block starts with one byte, the 6 lsb specify the type of block, the 2 msb specify the size of the next value (1, 2, 4 or 8 bytes) which specifies the size in bytes of the rest of the block. Data blocks can be nested, resulting in pretty much the binary version of the json file.
