### PR TITLE
Various changes

### DIFF
--- a/src/FbxConvCommand.h
+++ b/src/FbxConvCommand.h
@@ -36,14 +36,14 @@ struct FbxConvCommand {
 		flipV = false;
 		packColors = false;
 		verbose = false;
-		maxNodePartBonesCount = (1<<15)-1;
+		maxNodePartBonesCount = 12;
 		maxVertexBonesCount = 4;
 		maxVertexCount = (1<<15)-1;
 		maxIndexCount = (1<<15)-1;
 		outType = inType = FILETYPE_AUTO;
 		for (int i = 1; i < argc; i++) {
 			const char *arg = argv[i];
-			const int len = strlen(arg);
+			const int len = (int)strlen(arg);
 			if (len > 1 && arg[0] == '-') {
 				if (arg[1] == '?')
 					help = true;
@@ -100,7 +100,7 @@ struct FbxConvCommand {
 		printf("-f       : Flip the V texture coordinates.\n");
 		printf("-p       : Pack vertex colors to one float.\n");
 		printf("-m <size>: The maximum amount of vertices or indices a mesh may contain (default: 32k)\n");
-		printf("-b <size>: The maximum amount of bones a nodepart can contain (default: unlimited)\n");
+		printf("-b <size>: The maximum amount of bones a nodepart can contain (default: 12)\n");
 		printf("-w <size>: The maximum amount of bone weights per vertex (default: 4)\n");
 		printf("-v       : Verbose: print additional progress information\n");
 		printf("\n");
@@ -152,7 +152,7 @@ private:
 	}
 
 	int guessType(const std::string &fn, const int &def = -1) {
-		int o = fn.find_last_of('.');
+		int o = (int)fn.find_last_of('.');
 		if (o == std::string::npos)
 			return def;
 		std::string ext = fn.substr(++o, fn.length() - o);
@@ -160,7 +160,7 @@ private:
 	}
 
 	void setExtension(std::string &fn, const std::string &ext) const {
-		int o = fn.find_last_of('.');
+		int o = (int)fn.find_last_of('.');
 		if (o == std::string::npos)
 			fn += "." + ext;
 		else

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,7 +42,6 @@ int process(int argc, const char** argv) {
 		printf("Error loading source file\n");
 		return 1;
 	}
-
 	modeldata::Model *model = new modeldata::Model();
 
 	for (std::map<std::string, TextureFileInfo>::iterator it = reader.textureFiles.begin(); it != reader.textureFiles.end(); ++it)

--- a/src/modeldata/Attributes.h
+++ b/src/modeldata/Attributes.h
@@ -100,7 +100,7 @@ namespace modeldata {
 			unsigned int result = 0;
 			for (unsigned int i = 0; i < ATTRIBUTE_COUNT; i++)
 				if (has(i))
-					result += ATTRIBUTE_SIZE(i);
+					result += (unsigned int)ATTRIBUTE_SIZE(i);
 			return result;
 		}
 
@@ -132,7 +132,7 @@ namespace modeldata {
 			for (unsigned int i = 0; i < ATTRIBUTE_COUNT; i++) {
 				if (!has(i))
 					continue;
-				const unsigned short is = ATTRIBUTE_SIZE(i);
+				const unsigned short is = (unsigned short)ATTRIBUTE_SIZE(i);
 				if ((s + is) > v)
 					return AttributeTypes[i][v-s];
 				s+=is;

--- a/src/modeldata/Material.h
+++ b/src/modeldata/Material.h
@@ -85,7 +85,7 @@ namespace modeldata {
 		}
 
 		int getTextureIndex(const Texture * const &texture) const {
-			int n = textures.size();
+			int n = (int)textures.size();
 			for (int i = 0; i < n; i++)
 				if (textures[i] == texture)
 					return i;

--- a/src/modeldata/Mesh.h
+++ b/src/modeldata/Mesh.h
@@ -52,19 +52,19 @@ namespace modeldata {
 		inline unsigned int indexCount() {
 			unsigned int result = 0;
 			for (std::vector<MeshPart *>::const_iterator itr = parts.begin(); itr != parts.end(); ++itr)
-				result += (*itr)->indices.size();
+				result += (unsigned int)(*itr)->indices.size();
 			return result;
 		}
 
 		inline unsigned int add(const float *vertex) {
 			const unsigned int hash = calcHash(vertex, vertexSize);
-			const unsigned int n = hashes.size();
+			const unsigned int n = (unsigned int)hashes.size();
 			for (unsigned int i = 0; i < n; i++)
 				if ((hashes[i] == hash) && compare(&vertices[i*vertexSize], vertex, vertexSize))
 					return i;
 			hashes.push_back(hash);
 			vertices.insert(vertices.end(), &vertex[0], &vertex[vertexSize]);
-			return hashes.size() - 1;
+			return (unsigned int)hashes.size() - 1;
 		}
 
 		inline unsigned int calcHash(const float *vertex, const unsigned int size) {

--- a/src/modeldata/MeshPart.h
+++ b/src/modeldata/MeshPart.h
@@ -20,7 +20,7 @@ namespace modeldata {
 		std::string id;
 		std::vector<unsigned short> indices;
 		unsigned int primitiveType;
-		std::vector<const FbxCluster *> sourceBones;
+		std::vector<FbxCluster *> sourceBones;
 
 		MeshPart() : primitiveType(0) {}
 

--- a/src/readers/FbxMeshInfo.h
+++ b/src/readers/FbxMeshInfo.h
@@ -45,7 +45,7 @@ namespace readers {
 		// The number of mash parts within the mesh
 		int meshPartCount;
 		// The applied skin or 0 if not available
-		const FbxSkin * const skin;
+		FbxSkin * const skin;
 		// The blendweights per control point
 		std::vector<BlendWeight> *pointBlendWeights;
 		// The collection of bones per mesh part
@@ -126,7 +126,7 @@ namespace readers {
 				delete[] partUVBounds;
 		}
 
-		inline const FbxCluster *getBone(const unsigned int &idx) const {
+		inline FbxCluster *getBone(const unsigned int &idx) {
 			return skin ? skin->GetCluster(idx) : 0;
 		}
 
@@ -212,7 +212,7 @@ namespace readers {
 
 		inline void getBlendWeight(float * const &data, unsigned int &offset, const unsigned int &weightIndex, const unsigned int &poly, const unsigned int &polyIndex, const unsigned int &point) const {
 			const std::vector<BlendWeight> &weights = pointBlendWeights[point];
-			const unsigned int s = weights.size();
+			const unsigned int s = (unsigned int)weights.size();
 			const BlendBones &bones = partBones[polyPartMap[poly]].bones[polyPartBonesMap[poly]];
 			data[offset++] = weightIndex < s ? (float)bones.idx(weights[weightIndex].index) : 0.f;
 			data[offset++] = weightIndex < s ? weights[weightIndex].weight : 0.f;
@@ -325,7 +325,7 @@ namespace readers {
 				for (std::vector<BlendWeight>::iterator itr = pointBlendWeights[i].begin(); itr != pointBlendWeights[i].end(); ++itr)
 					(*itr).weight /= len;
 				if (pointBlendWeights[i].size() > vertexBlendWeightCount)
-					vertexBlendWeightCount = pointBlendWeights[i].size();
+					vertexBlendWeightCount = (unsigned int)pointBlendWeights[i].size();
 			}
 			if (vertexBlendWeightCount > 0 && forceMaxVertexBlendWeightCount)
 				vertexBlendWeightCount = maxVertexBlendWeightCount;

--- a/src/readers/util.h
+++ b/src/readers/util.h
@@ -124,7 +124,7 @@ namespace readers {
 			return (*this);
 		}
 		inline unsigned int size() const {
-			return bones.size();
+			return (unsigned int)bones.size();
 		}
 		inline BlendBones &operator[](const unsigned int &idx) {
 			return bones[idx];


### PR DESCRIPTION
- Small changes regarding FBX SDK 2014 update
- Small changes regarding compiler warnings
- Default maxNodePartBonesCount to 12 just like DefaultShaderProvider
- Always convert the axis system if needed (and possible)
- Move getBindPose to its own method for easy debugging and take getTransformMatrix into account.

Few things I found, that might cause issues:
- Blender does not correctly export the axis system (if you export with Z-up and inspect the FBX file, you'll see it still has UpAxis set to 1 which is Y). This means exported models from Blender with not Y-up, will not be automatically converted (causing the model to be rotated 90 degress on the X-axis).
- FBX has the ability to not only use bone transforms, but also a pose for the skinned mesh. When converting axis system, Maya recalculates the bone transforms, but blender doesn't. I tried to deduct the bone transform, but I cant really test it.
