### PR TITLE
Fix opacity

### DIFF
--- a/src/modeldata/Material.h
+++ b/src/modeldata/Material.h
@@ -58,7 +58,8 @@ namespace modeldata {
 			memset(ambient,  0, sizeof(ambient));
 			memset(emissive, 0, sizeof(emissive));
 			memset(specular, 0, sizeof(specular));
-			shininess = opacity = 0.f;
+			shininess = 0.f;
+			opacity = 1.f;
 		}
 
 		Material(const Material &copyFrom) {

--- a/src/readers/FbxConverter.h
+++ b/src/readers/FbxConverter.h
@@ -386,7 +386,10 @@ namespace readers {
 			addTextures(result->textures, lambert->Emissive, Material::Texture::Emissive);
 			addTextures(result->textures, lambert->Bump, Material::Texture::Bump);
 			addTextures(result->textures, lambert->NormalMap, Material::Texture::Normal);
-			result->opacity = 1.f - (float)lambert->TransparencyFactor.Get();
+			FbxDouble factor = lambert->TransparencyFactor.Get();
+			FbxDouble3 color = lambert->TransparentColor.Get();
+			FbxDouble trans = (color[0] * factor + color[1] * factor + color[2] * factor) / 3.0;
+			result->opacity = 1.f - (float)trans;
 
 			if (!material->Is<FbxSurfacePhong>())
 				return result;


### PR DESCRIPTION
TransparencyFactor and Opacity are a single value within an FBX file and according to the FBX SDK docs it should contain a value ranging from 0 (full opacity) to 1 (full transparent). But it seems like fbxsdk converts it to TransparencyColor anyway. Not sure if that's a 2014 feature or was in there before. Anyway, this should fix it.
