### PR TITLE
Added support for specular shininess parameter

### DIFF
--- a/src/readers/FbxConverter.h
+++ b/src/readers/FbxConverter.h
@@ -510,7 +510,10 @@ namespace readers {
 				return result;
 
 			FbxSurfacePhong * const &phong = (FbxSurfacePhong *)material;
+
 			set<3>(result->specular, phong->Specular.Get().mData);
+			result->shininess = (float)phong->Shininess.Get();
+
 			addTextures(result->textures, phong->Specular, Material::Texture::Specular);
 			addTextures(result->textures, phong->Reflection, Material::Texture::Reflection);
 			return result;


### PR DESCRIPTION
Added support for exporting of the shininess parameter (hardness of the specular color of a material). It was not exported from an input model before.

Just one line of code changed + added some white space.

Proposed modification can be easily tested by comparing conversion of samples/cube.dae model to .g3dj before and after applying the pull request (fbx-conv cube.dae cube.g3dj)

Regards,
Jarek
