### PR TITLE
Update FbxConverter.h

### DIFF
--- a/src/readers/FbxConverter.h
+++ b/src/readers/FbxConverter.h
@@ -620,7 +620,7 @@ namespace readers {
 							if ( propName == "DeformPercent" )
 							{
 								// When using this propName in model an unhandled exception is launched in sentence node->LclTranslation.GetName()
-								log->warning("Skipping propName '" + propName + "'");
+								log->warning("Skipping propName 'DeformPercent'");
 								continue;
 							}
 


### PR DESCRIPTION
This patch avoids to throw an unhandled exception when accesing "node->LclTranslation.GetName()" in case of propName == deformPercent 
