### PR TITLE
Emissive Property Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Command-line Usage
 *   **`-m <size>`**			-The maximum amount of vertices or indices a mesh may contain (default: 32k)
 *   **`-b <size>`**			-The maximum amount of bones a nodepart can contain (default: 12)
 *   **`-w <size>`**			-The maximum amount of bone weights per vertex (default: 4)
-*   **`-e**         -Force emissive property to [0,0,0]
+*   **`-e`**         -Force emissive property to [0,0,0]
 *   **`-v`**				-Verbose: print additional progress information
 
 ###Example

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Command-line Usage
 *   **`-m <size>`**			-The maximum amount of vertices or indices a mesh may contain (default: 32k)
 *   **`-b <size>`**			-The maximum amount of bones a nodepart can contain (default: 12)
 *   **`-w <size>`**			-The maximum amount of bone weights per vertex (default: 4)
+*   **`-e**         -Force emissive property to [0,0,0]
 *   **`-v`**				-Verbose: print additional progress information
 
 ###Example

--- a/src/FbxConv.h
+++ b/src/FbxConv.h
@@ -160,8 +160,9 @@ class FbxConv {
 				log->error(log::eExportFiletypeUnknown);
 				break;
 			}
+            jsonWriter->settings = settings;
 
-			if (jsonWriter) {
+			if(jsonWriter) {
 				(*jsonWriter) << model;
 				delete jsonWriter;
 				result = true;

--- a/src/FbxConv.h
+++ b/src/FbxConv.h
@@ -160,7 +160,7 @@ class FbxConv {
 				log->error(log::eExportFiletypeUnknown);
 				break;
 			}
-            jsonWriter->settings = settings;
+			jsonWriter->settings = settings;
 
 			if(jsonWriter) {
 				(*jsonWriter) << model;

--- a/src/FbxConvCommand.h
+++ b/src/FbxConvCommand.h
@@ -112,7 +112,7 @@ struct FbxConvCommand {
 		printf("-b <size>: The maximum amount of bones a nodepart can contain (default: 12)\n");
 		printf("-w <size>: The maximum amount of bone weights per vertex (default: 4)\n");
 		printf("-v       : Verbose: print additional progress information\n");
-        printf("-e       : Force emissive property to [0,0,0].");
+		printf("-e       : Force emissive property to [0,0,0].");
 		printf("\n");
 		printf("<input>  : The filename of the file to convert.\n");
 		printf("<output> : The filename of the converted file.\n");

--- a/src/FbxConvCommand.h
+++ b/src/FbxConvCommand.h
@@ -39,20 +39,23 @@ struct FbxConvCommand {
 
 		settings->flipV = false;
 		settings->packColors = false;
-		settings->verbose = false;
+        settings->verbose = false;
 		settings->maxNodePartBonesCount = 12;
 		settings->maxVertexBonesCount = 4;
 		settings->maxVertexCount = (1<<15)-1;
 		settings->maxIndexCount = (1<<15)-1;
 		settings->outType = FILETYPE_AUTO;
 		settings->inType = FILETYPE_AUTO;
+        settings->omitEmit = false;
 
 		for (int i = 1; i < argc; i++) {
 			const char *arg = argv[i];
 			const int len = (int)strlen(arg);
-			if (len > 1 && arg[0] == '-') {
-				if (arg[1] == '?')
-					help = true;
+            if(len > 1 && arg[0] == '-') {
+                if(arg[1] == '?')
+                    help = true;
+                else if(arg[1] == 'e')
+                    settings->omitEmit = true;
 				else if (arg[1] == 'f')
 					settings->flipV = true;
 				else if (arg[1] == 'v')
@@ -109,6 +112,7 @@ struct FbxConvCommand {
 		printf("-b <size>: The maximum amount of bones a nodepart can contain (default: 12)\n");
 		printf("-w <size>: The maximum amount of bone weights per vertex (default: 4)\n");
 		printf("-v       : Verbose: print additional progress information\n");
+        printf("-e       : Force emissive property to [0,0,0].");
 		printf("\n");
 		printf("<input>  : The filename of the file to convert.\n");
 		printf("<output> : The filename of the converted file.\n");

--- a/src/FbxConvCommand.h
+++ b/src/FbxConvCommand.h
@@ -51,7 +51,7 @@ struct FbxConvCommand {
 		for (int i = 1; i < argc; i++) {
 			const char *arg = argv[i];
 			const int len = (int)strlen(arg);
-            if(len > 1 && arg[0] == '-') {
+			if(len > 1 && arg[0] == '-') {
 				if(arg[1] == '?')
 				    help = true;
 				else if(arg[1] == 'e')

--- a/src/FbxConvCommand.h
+++ b/src/FbxConvCommand.h
@@ -39,23 +39,23 @@ struct FbxConvCommand {
 
 		settings->flipV = false;
 		settings->packColors = false;
-        settings->verbose = false;
+		settings->verbose = false;
 		settings->maxNodePartBonesCount = 12;
 		settings->maxVertexBonesCount = 4;
 		settings->maxVertexCount = (1<<15)-1;
 		settings->maxIndexCount = (1<<15)-1;
 		settings->outType = FILETYPE_AUTO;
 		settings->inType = FILETYPE_AUTO;
-        settings->omitEmit = false;
+		settings->omitEmit = false;
 
 		for (int i = 1; i < argc; i++) {
 			const char *arg = argv[i];
 			const int len = (int)strlen(arg);
             if(len > 1 && arg[0] == '-') {
-                if(arg[1] == '?')
-                    help = true;
-                else if(arg[1] == 'e')
-                    settings->omitEmit = true;
+				if(arg[1] == '?')
+				    help = true;
+				else if(arg[1] == 'e')
+				    settings->omitEmit = true;
 				else if (arg[1] == 'f')
 					settings->flipV = true;
 				else if (arg[1] == 'v')

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -31,6 +31,7 @@ namespace fbxconv {
 #define FILETYPE_OUT_DEFAULT	FILETYPE_G3DB
 #define FILETYPE_IN_DEFAULT		FILETYPE_FBX
 
+
 struct Settings {
 	std::string inFile;
 	int inType;
@@ -51,6 +52,8 @@ struct Settings {
 	int maxVertexCount;
 	/** The maximum allowed amount of indices in one mesh, only used when deciding to merge meshes. */
 	int maxIndexCount;
+    /** Forces the emissive value to 0,0,0 when exporting, fixes some problems, enable by specifying -e */
+    bool omitEmit; 
 };
 
 }

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -52,8 +52,8 @@ struct Settings {
 	int maxVertexCount;
 	/** The maximum allowed amount of indices in one mesh, only used when deciding to merge meshes. */
 	int maxIndexCount;
-    /** Forces the emissive value to 0,0,0 when exporting, fixes some problems, enable by specifying -e */
-    bool omitEmit; 
+	/** Forces the emissive value to 0,0,0 when exporting, fixes some problems, enable by specifying -e */
+	bool omitEmit; 
 };
 
 }

--- a/src/json/BaseJSONWriter.h
+++ b/src/json/BaseJSONWriter.h
@@ -313,7 +313,7 @@ private:
 	}
 public:
 	unsigned int defaultDataLineSize;
-    fbxconv::Settings * settings;
+	fbxconv::Settings * settings;
 
 	BaseJSONWriter() : block(Block::ROOT), defaultDataLineSize(32) {}
 

--- a/src/json/BaseJSONWriter.h
+++ b/src/json/BaseJSONWriter.h
@@ -27,6 +27,7 @@
 #include <string>
 #include <cassert>
 #include <stdio.h>
+#include "../Settings.h"
 
 namespace json {
 
@@ -128,7 +129,7 @@ protected:
 		Block(const Type &type, const long long &capacity = -1, const unsigned int maxLineSize = 0) 
 			: type(type), capacity(capacity), size(0), wroteKey(false), maxLineSize(maxLineSize), lineSize(0) {}
 	};
-
+   
 private:
 	std::stack<Block> blocks;
 	Block block;
@@ -312,6 +313,7 @@ private:
 	}
 public:
 	unsigned int defaultDataLineSize;
+    fbxconv::Settings * settings;
 
 	BaseJSONWriter() : block(Block::ROOT), defaultDataLineSize(32) {}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  ******************************************************************************/
 /** @author Xoppa */
+#define _CRT_NO_VA_START_VALIDATION
+
 #if defined(_MSC_VER) && defined(_DEBUG)
 #define _CRTDBG_MAP_ALLOC
 #include <stdlib.h>
@@ -37,8 +39,6 @@
 using namespace fbxconv;
 using namespace fbxconv::modeldata;
 using namespace fbxconv::readers;
-
-
 
 int process(int argc, const char** argv) {
 	log::Log log(new log::DefaultMessages(), -1);

--- a/src/modeldata/Material.h
+++ b/src/modeldata/Material.h
@@ -106,6 +106,7 @@ namespace modeldata {
 		OptionalValue<float, 3> diffuse;
 		OptionalValue<float, 3> ambient;
 		OptionalValue<float, 3> emissive;
+        OptionalValue<float, 1> emissiveFactor;
 		OptionalValue<float, 3> specular;
 		OptionalValue<float> shininess;
 		OptionalValue<float> opacity;

--- a/src/modeldata/Material.h
+++ b/src/modeldata/Material.h
@@ -106,7 +106,7 @@ namespace modeldata {
 		OptionalValue<float, 3> diffuse;
 		OptionalValue<float, 3> ambient;
 		OptionalValue<float, 3> emissive;
-        OptionalValue<float, 1> emissiveFactor;
+		OptionalValue<float, 1> emissiveFactor;
 		OptionalValue<float, 3> specular;
 		OptionalValue<float> shininess;
 		OptionalValue<float> opacity;

--- a/src/modeldata/Serialization.cpp
+++ b/src/modeldata/Serialization.cpp
@@ -114,18 +114,18 @@ void Material::serialize(json::BaseJSONWriter &writer) const {
 		writer << "ambient" = ambient.value;
 	if (diffuse.valid)
 		writer << "diffuse" = diffuse.value;
-    if(emissive.valid) {
-        /*
-        A problem was introduced in LibGDX version 1.9.9 as it included support for emissive textures. FBX-conv was exporting
-        g3db & g3dj files with incorrect emissive properties. This fix reads the emissiveFactor value from the fbx file
-        and multiplies it by each component in the emissive[3] array producing correct emissive values now.
+	if(emissive.valid) {
+		/*
+		A problem was introduced in LibGDX version 1.9.9 as it included support for emissive textures. FBX-conv was exporting
+		g3db & g3dj files with incorrect emissive properties. This fix reads the emissiveFactor value from the fbx file
+		and multiplies it by each component in the emissive[3] array producing correct emissive values now.
         */
-        float z[3] = { emissive.value[0] * emissiveFactor.value, emissive.value[1] * emissiveFactor.value, emissive.value[2] * emissiveFactor.value };
-        if(writer.settings->omitEmit) {
-            z[0] = 0; z[1] = 0; z[2] = 0;
-        }
-        writer << "emissive" = z;
-    }
+		float z[3] = { emissive.value[0] * emissiveFactor.value, emissive.value[1] * emissiveFactor.value, emissive.value[2] * emissiveFactor.value };
+		if(writer.settings->omitEmit) {
+			z[0] = 0; z[1] = 0; z[2] = 0;
+		}
+		writer << "emissive" = z;
+	}
 	if (opacity.valid)
 		writer << "opacity" = opacity.value;
 	if (specular.valid)

--- a/src/modeldata/Serialization.cpp
+++ b/src/modeldata/Serialization.cpp
@@ -119,7 +119,7 @@ void Material::serialize(json::BaseJSONWriter &writer) const {
 		A problem was introduced in LibGDX version 1.9.9 as it included support for emissive textures. FBX-conv was exporting
 		g3db & g3dj files with incorrect emissive properties. This fix reads the emissiveFactor value from the fbx file
 		and multiplies it by each component in the emissive[3] array producing correct emissive values now.
-        */
+		*/
 		float z[3] = { emissive.value[0] * emissiveFactor.value, emissive.value[1] * emissiveFactor.value, emissive.value[2] * emissiveFactor.value };
 		if(writer.settings->omitEmit) {
 			z[0] = 0; z[1] = 0; z[2] = 0;

--- a/src/modeldata/Serialization.cpp
+++ b/src/modeldata/Serialization.cpp
@@ -114,8 +114,18 @@ void Material::serialize(json::BaseJSONWriter &writer) const {
 		writer << "ambient" = ambient.value;
 	if (diffuse.valid)
 		writer << "diffuse" = diffuse.value;
-	if (emissive.valid)
-		writer << "emissive" = emissive.value;
+    if(emissive.valid) {
+        /*
+        A problem was introduced in LibGDX version 1.9.9 as it included support for emissive textures. FBX-conv was exporting
+        g3db & g3dj files with incorrect emissive properties. This fix reads the emissiveFactor value from the fbx file
+        and multiplies it by each component in the emissive[3] array producing correct emissive values now.
+        */
+        float z[3] = { emissive.value[0] * emissiveFactor.value, emissive.value[1] * emissiveFactor.value, emissive.value[2] * emissiveFactor.value };
+        if(writer.settings->omitEmit) {
+            z[0] = 0; z[1] = 0; z[2] = 0;
+        }
+        writer << "emissive" = z;
+    }
 	if (opacity.valid)
 		writer << "opacity" = opacity.value;
 	if (specular.valid)

--- a/src/readers/FbxConverter.h
+++ b/src/readers/FbxConverter.h
@@ -559,10 +559,10 @@ namespace readers {
 				result->ambient.set(lambert->Ambient.Get().mData);
 			if (lambert->Diffuse.IsValid())
 				result->diffuse.set(lambert->Diffuse.Get().mData);
-            if(lambert->Emissive.IsValid()) {
-                result->emissiveFactor.set(lambert->EmissiveFactor.Get());
-                result->emissive.set(lambert->Emissive.Get().mData);
-            }
+			if(lambert->Emissive.IsValid()) {
+				result->emissiveFactor.set(lambert->EmissiveFactor.Get());
+				result->emissive.set(lambert->Emissive.Get().mData);
+			}
 
 			addTextures(result->id.c_str(), result->textures, lambert->Ambient, Material::Texture::Ambient);
 			addTextures(result->id.c_str(), result->textures, lambert->Diffuse, Material::Texture::Diffuse);

--- a/src/readers/FbxConverter.h
+++ b/src/readers/FbxConverter.h
@@ -559,8 +559,10 @@ namespace readers {
 				result->ambient.set(lambert->Ambient.Get().mData);
 			if (lambert->Diffuse.IsValid())
 				result->diffuse.set(lambert->Diffuse.Get().mData);
-			if (lambert->Emissive.IsValid())
-				result->emissive.set(lambert->Emissive.Get().mData);
+            if(lambert->Emissive.IsValid()) {
+                result->emissiveFactor.set(lambert->EmissiveFactor.Get());
+                result->emissive.set(lambert->Emissive.Get().mData);
+            }
 
 			addTextures(result->id.c_str(), result->textures, lambert->Ambient, Material::Texture::Ambient);
 			addTextures(result->id.c_str(), result->textures, lambert->Diffuse, Material::Texture::Diffuse);


### PR DESCRIPTION
LibGDX update 1.9.9 added support for loading the emissive property (not previously used) for 3D models. An issue with FBX-conv caused the emissive property to be set to the diffuse value or other random values and cause all models exported and loaded into LibGDX to appear white. 

The bug is described in more detail here: https://github.com/libgdx/libgdx/issues/5529

This pull request contains a fix for the emissive property (by reading the emissive factor from FBX-SDK and multiplying it against each item in the emissive array) and an option to disable the emissive property all together if desired.