### PR TITLE
fix FBX SDK lib path for linux build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
       - mkdir fbx-sdk-linux
       - yes yes | ./fbx20151_fbxsdk_linux fbx-sdk-linux
       - export FBX_SDK_ROOT=$PWD/fbx-sdk-linux
-      - export LD_LIBRARY_PATH=$FBX_SDK_ROOT/lib/gcc/x64/release/
+      - export LD_LIBRARY_PATH=$FBX_SDK_ROOT/lib/gcc4/x64/release/
       - ./generate_makefile
       - cd build/gmake/
     install: true


### PR DESCRIPTION
i followed exactly travis build (and prebuild) steps for linux locally and found a path mistake when running compiled binary.

it doesn't have impact on travis build since so files are only necessary at runtime but in case people (like me) want to build and run locally, it helps.

