### PR TITLE
FBX file version check

### DIFF
--- a/src/log/codes.h
+++ b/src/log/codes.h
@@ -40,10 +40,12 @@ LOG_ADD_CODE(eCommandLineInvalidVertexCount)
 LOG_ADD_CODE(eCommandLineUnknownFiletype)
 
 LOG_ADD_CODE(sSourceLoad)
+LOG_ADD_CODE(sSourceLoadFbxVersion)
 LOG_ADD_CODE(pSourceLoadFbxImport)
 LOG_ADD_CODE(wSourceLoadFbxNodeRrSs)
 LOG_ADD_CODE(eSourceLoadGeneral)
 LOG_ADD_CODE(eSourceLoadFiletypeUnknown)
+LOG_ADD_CODE(eSourceLoadFbxVersionUnknown)
 LOG_ADD_CODE(eSourceLoadFbxSdk)
 
 LOG_ADD_CODE(sSourceConvert)

--- a/src/log/messages.h
+++ b/src/log/messages.h
@@ -41,10 +41,12 @@ LOG_SET_MSG(eCommandLineInvalidVertexCount,		"Maximum vertex count must be betwe
 LOG_SET_MSG(eCommandLineUnknownFiletype,		"Unknown filetype: %s")
 
 LOG_SET_MSG(sSourceLoad,						"Loading source file")
+LOG_SET_MSG(sSourceLoadFbxVersion,              "FBX file version %d %d %d")
 LOG_SET_MSG(pSourceLoadFbxImport,				"Import FBX %01.2f%% %s")
 LOG_SET_MSG(wSourceLoadFbxNodeRrSs,				"[%s] Node uses RrSs mode, transformation might be incorrect")
 LOG_SET_MSG(eSourceLoadGeneral,					"Error loading source file")
 LOG_SET_MSG(eSourceLoadFiletypeUnknown,			"Unknown source filetype")
+LOG_SET_MSG(eSourceLoadFbxVersionUnknown,       "Unknown FBX file version, supported version up to %d (may be too recent)")
 LOG_SET_MSG(eSourceLoadFbxSdk,					"FBX SDK encountered an error (%d): %s")
 
 LOG_SET_MSG(sSourceConvert,						"Converting source file")

--- a/src/readers/FbxConverter.h
+++ b/src/readers/FbxConverter.h
@@ -112,6 +112,16 @@ namespace readers {
 			importer->ParseForStatistics(true);
 
 			if (importer->Initialize(settings->inFile.c_str(), -1, manager->GetIOSettings())) {
+
+				int major = 0, minor = 0, revision = 0;
+				importer->GetFileVersion(major, minor, revision);
+				log->status(fbxconv::log::sSourceLoadFbxVersion, major, minor, revision);
+
+				FbxIOFileHeaderInfo * info = importer->GetFileHeaderInfo();
+				if(info->mFileVersion == 0) {
+					log->error(fbxconv::log::eSourceLoadFbxVersionUnknown, FBX_DEFAULT_FILE_VERSION);
+				}
+
 				importer->GetAxisInfo(&axisSystem, &systemUnits);
 				scene = FbxScene::Create(manager,"__FBX_SCENE__");
 				importer->Import(scene);


### PR DESCRIPTION
recent FBX file version (7500) fails silently and output empty G3D file.

surprizingly, FBX SDK importer doesn't raise any error, so i added a check. I didn't found a better way to check this in FBX SDK documentation : 

* with a supported file (7400), GetFileVersion reports 7.4.0 and mFileVersion is 7400
* with an unsupported file (7500), GetFileVersion reports 7.5.0 but mFileVersion is 0

So i made an assumption on mFileVersion value and only output an error log.

notes: 

* latest blender FBX exporter output supported FBX files (7400)
* supported versions are listed in FBX SDK sources : fileio/fbx/fbxio.h
* i included an unsupported FBX file (7500) for testing purpose.

[Dirt_Cube__texture.zip](https://github.com/libgdx/fbx-conv/files/3554732/Dirt_Cube__texture.zip)
