### PR TITLE
Fix linkage to libxml2 on linux

### DIFF
--- a/premake.lua
+++ b/premake.lua
@@ -125,6 +125,7 @@ project "fbx-conv"
 			"png",
 			"z",
 			"pthread",
+			"xml2",
 			"fbxsdk",
 			"dl",
 		}


### PR DESCRIPTION
I am on Arch linux, and the build fails with undefined references to `libxml2` symbols used by `libfbxsdk.so`.
According to [this post](https://forums.autodesk.com/t5/fbx-forum/linking-fbxsdk-2019-2-with-libxml2/td-p/8993807), a build linking to `libfbxsdk.so` should first link to `libxml2`.

This pull request does just that and then it works on my environment.